### PR TITLE
clean up reaper to not check for threadpool "type" and just use pruni…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
- - 1.9
- - 2.0
- - 2.1
- - jruby
+  - 1.9
+  - 2.0
+  - 2.1
+  - jruby

--- a/lib/lifeguard/reaper.rb
+++ b/lib/lifeguard/reaper.rb
@@ -16,30 +16,14 @@ module Lifeguard
       @thread.alive?
     end
 
-    def reap!
-      @threadpool.prune_busy_threads
-    end
-
     def run!
       loop do
         sleep(@reaping_interval)
-        reap!
-        timeout!
-        ready_thread_count = @threadpool.pool_size - @threadpool.busy_size
-        
-        if ready_thread_count > 0 && @threadpool.respond_to?(:check_queued_jobs)
-          ready_thread_count.times do
-            @threadpool.check_queued_jobs
-          end
-        end
+        @threadpool.prune_busy_threads if @threadpool
+        @threadpool.timeout! if @threadpool
       end
     rescue
       retry
     end
-
-    def timeout!
-      @threadpool.timeout!
-    end
-
   end
 end

--- a/lib/lifeguard/reaper.rb
+++ b/lib/lifeguard/reaper.rb
@@ -7,6 +7,7 @@ module Lifeguard
       @threadpool = threadpool
       @reaping_interval = reaping_interval
       @thread = ::Thread.new { self.run! }
+      ::Thread.pass until alive?
     end
 
     ##

--- a/lib/lifeguard/threadpool.rb
+++ b/lib/lifeguard/threadpool.rb
@@ -1,17 +1,19 @@
 require 'thread'
+require 'securerandom'
 
 module Lifeguard
   class Threadpool
     DEFAULT_REAPING_INTERVAL = 5 # in seconds
     DEFAULT_POOL_SIZE = 2
 
-    attr_accessor :options, :pool_size
+    attr_accessor :name, :options, :pool_size
 
     ##
     # Constructor
     #
     def initialize(opts = {})
       @options = opts
+      @name = opts[:name] || ::SecureRandom.uuid
       @pool_size = opts[:pool_size] || DEFAULT_POOL_SIZE
 
       # Important info about "timeout", it is controlled by the reaper

--- a/spec/lifeguard/reaper_spec.rb
+++ b/spec/lifeguard/reaper_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe ::Lifeguard::Reaper do
-  pending
+  skip
 end

--- a/spec/lifeguard/threadpool_spec.rb
+++ b/spec/lifeguard/threadpool_spec.rb
@@ -9,15 +9,31 @@ describe ::Lifeguard::Threadpool do
     sleep(0.1)
   end
 
+  describe "#busy?" do
+    it "reports false when the busy_size < pool_size" do
+      threadpool = described_class.new(:pool_size => 1, :reaping_interval => 1)
+      expect(threadpool.busy?).to be false
+    end
+
+    it "reports true when the busy_size >= pool_size" do
+      threadpool = described_class.new(:pool_size => 1, :reaping_interval => 1)
+      threadpool.async do
+        sleep(1)
+      end
+
+      expect(threadpool.busy?).to be true
+    end
+  end
+
   describe "#timeout!" do
     it "doesn't timeout when no timeout set" do
       threadpool = described_class.new()
-      threadpool.timeout?.should be_false
+      threadpool.timeout?.should be false
     end
 
     it "does timeout when timeout set" do
       threadpool = described_class.new(:timeout => 30)
-      threadpool.timeout?.should be_true
+      threadpool.timeout?.should be true
     end
 
     it "uses the reaper to timeout threads that are all wiley" do
@@ -39,7 +55,7 @@ describe ::Lifeguard::Threadpool do
       sleep(0.1)
       subject.kill!
       sleep(1)
-      @expected.should be_false
+      @expected.should be false
     end
 
     it 'rejects all pending tasks' do
@@ -49,7 +65,7 @@ describe ::Lifeguard::Threadpool do
       sleep(0.1)
       subject.kill!
       sleep(1)
-      @expected.should be_false
+      @expected.should be false
     end
 
     it 'kills all threads' do
@@ -69,7 +85,7 @@ describe ::Lifeguard::Threadpool do
     end
 
     it 'returns true when the block is added to the queue' do
-      subject.async{ sleep }.should be_true
+      subject.async{ sleep }.should be true
     end
 
     it 'calls the block with the given arguments' do

--- a/spec/lifeguard/threadpool_spec.rb
+++ b/spec/lifeguard/threadpool_spec.rb
@@ -25,6 +25,15 @@ describe ::Lifeguard::Threadpool do
     end
   end
 
+  describe "#name" do
+    let(:name) { "AWESOME_NAME" }
+
+    it "allows a name to be set via an option" do
+      threadpool = described_class.new(:name => name, :pool_size => 1, :reaping_interval => 1)
+      expect(threadpool.name).to eq(name)
+    end
+  end
+
   describe "#timeout!" do
     it "doesn't timeout when no timeout set" do
       threadpool = described_class.new()

--- a/spec/lifeguard/threadpool_spec.rb
+++ b/spec/lifeguard/threadpool_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe ::Lifeguard::Threadpool do
-
   subject { described_class.new(:pool_size => 5) }
 
   after(:each) do
@@ -78,13 +77,14 @@ describe ::Lifeguard::Threadpool do
     end
 
     it 'kills all threads' do
+      subject
       before_thread_count = Thread.list.size
       100.times { subject.async{ sleep(1) } }
       sleep(0.1)
       Thread.list.size.should > before_thread_count
       subject.kill!
       sleep(0.1)
-      Thread.list.size.should eq(before_thread_count + 1) # +1 for the reaper
+      Thread.list.size.should eq(before_thread_count)
     end
   end
 


### PR DESCRIPTION
…ng interface; update specs; add busy? method to determine if threadpool is busy

may address the concern about the `busy?` method in action_subscriber

@film42 @liveh2o 
