### PR TITLE
Gracefully degrade to synchronous when the queue is busy

### DIFF
--- a/lib/lifeguard/infinite_threadpool.rb
+++ b/lib/lifeguard/infinite_threadpool.rb
@@ -18,9 +18,16 @@ module Lifeguard
 
     def async(*args, &block)
       return false if @shutdown
+      sleep 0.5 if @queued_jobs.size > 1000
       @queued_jobs << { :args => args, :block => block }
 
       return true
+    end
+
+    def shutdown(shutdown_timeout = 30)
+      @shutdown = true
+      @scheduler.join
+      super(shutdown_timeout)
     end
 
     def create_scheduler

--- a/lib/lifeguard/infinite_threadpool.rb
+++ b/lib/lifeguard/infinite_threadpool.rb
@@ -6,10 +6,8 @@ module Lifeguard
 
     def initialize(opts = {})
       super(opts)
-      @queued_jobs = ::Queue.new
       @shutdown = false
       @super_async_mutex = ::Mutex.new
-      @scheduler = create_scheduler
     end
 
     def async(*args, &block)

--- a/lib/lifeguard/infinite_threadpool.rb
+++ b/lib/lifeguard/infinite_threadpool.rb
@@ -16,7 +16,7 @@ module Lifeguard
       if busy?
         block.call(*args) rescue nil
       else
-        super(args, &block)
+        super(*args, &block)
       end
 
       return true

--- a/lib/lifeguard/infinite_threadpool.rb
+++ b/lib/lifeguard/infinite_threadpool.rb
@@ -12,14 +12,17 @@ module Lifeguard
       @scheduler = create_scheduler
     end
 
-    # Handle to original async method
-    # for check_queued_jobs to use directly
+    # Handle to original async method # for check_queued_jobs to use directly
     alias_method :super_async, :async
 
     def async(*args, &block)
       return false if @shutdown
-      sleep 0.5 if @queued_jobs.size > 1000
-      @queued_jobs << { :args => args, :block => block }
+
+      if @queued_jobs.size > 1000
+        block.call(*args) rescue nil
+      else
+        @queued_jobs << { :args => args, :block => block }
+      end
 
       return true
     end


### PR DESCRIPTION
After firefighting an issue in prod due to action subscriber freezing (on lifeguard v0.1.0 as well as v0.0.9), I came up with this solution. This was the best compromise I found between throughput and dependability. I had a single subscriber processing on average of 1,000 messages per second for over 30 minutes without freezing.
