### PR TITLE
Let the interpreter prune busy threads for us

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ before_install:
 rvm:
   - 2.0
   - 2.1
+  - 2.3
   - jruby-9.1.2.0
+  - jruby-9.1.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 before_install:
   - gem install bundler
 rvm:
-  - 1.9
   - 2.0
   - 2.1
-  - jruby
+  - jruby-9.1.2.0

--- a/lib/lifeguard/reaper.rb
+++ b/lib/lifeguard/reaper.rb
@@ -20,7 +20,6 @@ module Lifeguard
     def run!
       loop do
         sleep(@reaping_interval)
-        @threadpool.prune_busy_threads if @threadpool
         @threadpool.timeout! if @threadpool
       end
     rescue

--- a/lib/lifeguard/threadpool.rb
+++ b/lib/lifeguard/threadpool.rb
@@ -24,7 +24,7 @@ module Lifeguard
       #
       @timeout = opts[:timeout]
       @mutex = ::Mutex.new
-      @busy_threads = []
+      @busy_threads = ThreadGroup.new
 
       restart_reaper_unless_alive
     end
@@ -37,20 +37,12 @@ module Lifeguard
     end
 
     def busy_size
-      @busy_threads.size
+      @busy_threads.list.size
     end
 
     def kill!
       @mutex.synchronize do
-        prune_busy_threads_without_mutex
-        @busy_threads.each { |busy_thread| busy_thread.kill }
-        prune_busy_threads_without_mutex
-      end
-    end
-
-    def on_thread_exit(thread)
-      @mutex.synchronize do
-        @busy_threads.delete(thread)
+        @busy_threads.list.each { |busy_thread| busy_thread.kill }
       end
     end
 
@@ -63,50 +55,28 @@ module Lifeguard
       end
 
       @mutex.synchronize do
-        prune_busy_threads_without_mutex
-
         if busy_size < pool_size
           queued_the_work = true
 
-          @busy_threads << ::Thread.new(block, args, self) do |callable, call_args, parent|
+          @busy_threads.add ::Thread.new(block, args, self) { |callable, call_args, parent|
             begin
               ::Thread.current[:__start_time_in_seconds__] = Time.now.to_i
               ::Thread.current.abort_on_exception = false
               callable.call(*call_args) # should we check the args? pass args?
-            ensure
-              parent.on_thread_exit(::Thread.current)
             end
-          end
+          }
         end
 
-        prune_busy_threads_without_mutex
         queued_the_work
       end
     end
 
-    def prune_busy_threads
+    def shutdown(shutdown_timeout = 3)
+      kill_at = Time.now.to_f + shutdown_timeout
+
       @mutex.synchronize do
-        prune_busy_threads_without_mutex
-      end
-    end
-
-    def shutdown(shutdown_timeout = 0)
-      @mutex.synchronize do
-        prune_busy_threads_without_mutex
-
-        if @busy_threads.size > 0
-          # Cut the shutdown_timeout by 10 and prune while things finish before the kill
-          (shutdown_timeout/10).times do 
-            sleep (shutdown_timeout / 10.0)
-            prune_busy_threads_without_mutex
-            break if busy_size == 0
-          end
-
-          sleep(shutdown_timeout/10)
-          @busy_threads.each { |busy_thread| busy_thread.kill }
-        end
-
-        prune_busy_threads_without_mutex
+        sleep 0.01 while busy_size > 0 && Time.now.to_f < kill_at
+        @busy_threads.list.each { |busy_thread| busy_thread.kill }
       end
     end
 
@@ -114,13 +84,11 @@ module Lifeguard
       return unless timeout?
 
       @mutex.synchronize do
-        @busy_threads.each do |busy_thread|
+        @busy_threads.list.each do |busy_thread|
           if (Time.now.to_i - busy_thread[:__start_time_in_seconds__] > @timeout)
             busy_thread.kill
           end
         end
-
-        prune_busy_threads_without_mutex
       end
     end
 
@@ -133,10 +101,6 @@ module Lifeguard
     ##
     # Private Instance Methods
     #
-    def prune_busy_threads_without_mutex
-      @busy_threads.select!(&:alive?)
-    end
-
     def restart_reaper_unless_alive
       return if @reaper && @reaper.alive?
 

--- a/lib/lifeguard/threadpool.rb
+++ b/lib/lifeguard/threadpool.rb
@@ -59,11 +59,9 @@ module Lifeguard
           queued_the_work = true
 
           @busy_threads.add ::Thread.new(block, args, self) { |callable, call_args, parent|
-            begin
-              ::Thread.current[:__start_time_in_seconds__] = Time.now.to_i
-              ::Thread.current.abort_on_exception = false
-              callable.call(*call_args) # should we check the args? pass args?
-            end
+            ::Thread.current[:__start_time_in_seconds__] = Time.now.to_i
+            ::Thread.current.abort_on_exception = false
+            callable.call(*call_args) # should we check the args? pass args?
           }
         end
 

--- a/spec/lifeguard/threadpool_spec.rb
+++ b/spec/lifeguard/threadpool_spec.rb
@@ -45,14 +45,17 @@ describe ::Lifeguard::Threadpool do
     end
 
     it "uses the reaper to timeout threads that are all wiley" do
+      expected = false
       threadpool = described_class.new(:timeout => 1, :reaping_interval => 1)
       threadpool.async do
-        sleep(10)
+        sleep(3)
+        expected = true
       end
 
       threadpool.busy_size.should eq(1)
       sleep(4)
       threadpool.busy_size.should eq(0)
+      expected.should be(false)
     end
   end
 
@@ -78,13 +81,12 @@ describe ::Lifeguard::Threadpool do
 
     it 'kills all threads' do
       subject
-      before_thread_count = Thread.list.size
       100.times { subject.async{ sleep(1) } }
       sleep(0.1)
-      Thread.list.size.should > before_thread_count
+      subject.busy_size.should eq(subject.pool_size)
       subject.kill!
       sleep(0.1)
-      Thread.list.size.should eq(before_thread_count)
+      subject.busy_size.should eq(0)
     end
   end
 


### PR DESCRIPTION
By using a ThreadGroup, we can get all of the pruning functionality for
free. Adding a thread to a thread group does not actually create an
additional reference to that thread, so they will still be garbage
collected normally when they finish.
