### PR TITLE
use condition variable to wait instead of pass

### DIFF
--- a/lib/lifeguard/infinite_threadpool.rb
+++ b/lib/lifeguard/infinite_threadpool.rb
@@ -14,16 +14,26 @@ module Lifeguard
       return false if @shutdown
 
       if busy?
+        job_mutex = ::Mutex.new
+        job_condition = ::ConditionVariable.new
         # Account for "weird" exceptions like Java Exceptions or higher up the chain
         # than what `rescue nil` will capture
-        new_thread = ::Thread.new(block, args) do |callable, call_args|
-          ::Thread.current[:__start_time_in_seconds__] = Time.now.to_i
-          ::Thread.current.abort_on_exception = false
+        job_mutex.synchronize do
+          new_thread = ::Thread.new(block, args) do |callable, call_args|
+            job_mutex.synchronize do
+              begin
+                ::Thread.current[:__start_time_in_seconds__] = Time.now.to_i
+                ::Thread.current.abort_on_exception = false
 
-          callable.call(*call_args)
+                callable.call(*call_args)
+              ensure
+                job_condition.signal
+              end
+            end
+          end
+
+          job_condition.wait(job_mutex)
         end
-
-        ::Thread.pass while new_thread.alive?
       else
         super(*args, &block)
       end

--- a/lib/lifeguard/threadpool.rb
+++ b/lib/lifeguard/threadpool.rb
@@ -59,8 +59,8 @@ module Lifeguard
           queued_the_work = true
 
           @busy_threads.add ::Thread.new(block, args, self) { |callable, call_args, parent|
-            ::Thread.current[:__start_time_in_seconds__] = Time.now.to_i
             ::Thread.current.abort_on_exception = false
+            ::Thread.current[:__start_time_in_seconds__] = Time.now.to_i
             callable.call(*call_args) # should we check the args? pass args?
           }
         end


### PR DESCRIPTION
@quixoten @film42 we switched to using a condition variable in ActionSubscriber because the pass mechanism can cause a lot of kernel CPU to happen; updating here and ready for 0.3.0 I belive
